### PR TITLE
Change in scripts to start project

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Bot and Dashboard to moderate and run the FreeCodeCamp twitch channel",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change helps newcomers start the project, they can just do 'npm start' from the root folder.  This change is until gulp or nodemon are added to the project as part of the dev modules 